### PR TITLE
phpunit strict option fix

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="./vendor/autoload.php"
          colors="true"
-         strict="true"
          verbose="true">
   <testsuites>
     <testsuite name="The project's test suite">


### PR DESCRIPTION
Ahoj Milane, zrušil jsem deprecated strict option. V nové verzi je strict rozděleno do více drobnějších paramaterů, viz. dokumentace.
